### PR TITLE
Change path parameter for /v2/naics/group/ endpoint to use String ins…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.trustedchoice"
-version = "1.0.3"
+version = "2.0.0"
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/trustedchoice/askkodiak/v2/client/AskKodiak.java
+++ b/src/main/java/com/trustedchoice/askkodiak/v2/client/AskKodiak.java
@@ -418,7 +418,7 @@ public interface AskKodiak {
      * @throws AskKodiakException error
      */
     @RequestLine("GET /v2/naics/group/{groupNumber}")
-    NaicsGroup getGroup(@Param("groupNumber") int groupNumber) throws AskKodiakException;
+    NaicsGroup getGroup(@Param("groupNumber") String groupNumber) throws AskKodiakException;
 
     /////////////////////////
     // Products API query models


### PR DESCRIPTION
…tead of int.

The /v2/naics/group/ endpoint takes an Ask Kodiak NAICS group id path parameter to return a
NaicsGroup. The Ask Kodiak NAICS group id can be a NAICS code or a range of NAICS codes
(e.g. 31-33). To accept a range of NAICS codes, a string value specifying the range
can passed to the /v2/naics/group/ endpoint. In this SDK, this endpoint was initially
setup to only accept parameters of type int. So, the groupNumber parameter for the
getGroup method associated with the /v2/naics/group/ endpoint was changed from int
to String. An Ask Kodiak NAICS group id with a range can now be specified.