### PR TITLE
Do Not Encode "+" Symbol in Query Parameters

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.trustedchoice"
-version = "3.0.2"
+version = "3.0.3"
 
 repositories {
     mavenCentral()
@@ -104,7 +104,7 @@ bintray {
 }
 
 val jacksonVersion = "2.9.8"
-val feignVersion = "10.2.0"
+val feignVersion = "11.1"
 val slf4jVersion = "1.7.26"
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.trustedchoice"
-version = "3.0.3"
+version = "3.1.0"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
- The AskKodiak API requires a "+" symbol to delimit list items in some
query parameters. When "+" is encoded to "%2B", then the API does not
return results as expected.

- The current implementation of `getProductsEligibleForCode` uses the
`QueryMap` annotation and does not set the value of `encoded`. This
means that a default value of `false` is used, so Feign assumes that
the query parameters are not already encoded, and it encodes them,
including replacing "+" symbols with "%2B".

- For the sake of backward compatibility, add an overload of
`getProductsEligibleForCode` to the`AskKodiak` interface that takes a
`Map` instead of an `EligibleQuery` as the `QueryMap` object. Then
made a default implementation of the existing
`getProductsEligibleForCode` method that builds a `Map` from an
`EligibleQuery` object (including encoding parameters except for "+"
symbols) and calls the new overload method

- Also upgraded the Feign dependency as there was an issue with
`encoded = true` being respected on the `QueryMap` annotation in the
old version