### PR TITLE
feature/AD-11692 Update publishing url and revert unnecessary check from previous PR

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,15 +51,12 @@ tasks.withType<Jar> {
 publishing {
     repositories {
         mavenLocal()
-        // Only add OSSRH repo if creds are present
-        if (project.hasProperty("ossrhUsername") && project.hasProperty("ossrhPassword")) {
-            maven {
-                name = "SonaTypeOSSRH"
-                url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2")
-                credentials {
-                    username = project.findProperty("ossrhUsername")?.toString()
-                    password = project.findProperty("ossrhPassword")?.toString()
-                }
+        maven {
+            name = "SonaTypeOSSRH"
+            url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2")
+            credentials {
+                username = project.findProperty("ossrhUsername")?.toString()
+                password = project.findProperty("ossrhPassword")?.toString()
             }
         }
     }


### PR DESCRIPTION
The sonatype process is in a weird place after the OSSRH service hit EOL. They don't have official Gradle support for their new system, only third party options which I was trying to avoid. They also support Maven natively but I do not want to convert a Gradle project to Maven

The "staging" url functions similar to how they used to behave, only without the UI we used to have. We send it to their staging area, then send a curl command to pull it into the new system UI. I documented the steps in the ask kodiak knowledge base article but it's a simple process. 

https://trustedchoice.myjetbrains.com/youtrack/articles/AD-A-75/How-To-Release-Ask-Kodiak-SDK-to-Maven-Central-Repository

I went with this approach to avoid major changes in the code/project setup, and to avoid relying on any third party Gradle implementations.